### PR TITLE
Patch pubmed restart

### DIFF
--- a/BACKEND/SCRIPT/CONFIG/CONFIG_JOB
+++ b/BACKEND/SCRIPT/CONFIG/CONFIG_JOB
@@ -61,7 +61,7 @@ SC	68	rmj_alfa					66							-1		-1	VARIANT			C	D	P		R	62|63|65														-1	R
 SC	109	prd_pubmed					101|102						-1		-1	PUBLI			C	P	P		S	/																-1	Push pubmed to prod
 SC	100	dl_pubmed					-1							-1		-1	PUBLI			C	D	D3		S	101|102|109															-1	Download latest pubmed
 SC	101	db_pubmed					100							-1		-1	PUBLI			C	D	P		S	102|100																-1	Push pubmed to database
-SC	102	db_pubmed_info				101							-1		-1	PUBLI			C	D	P		S	100o																-1	Push pubmed authors & institution to database
+SC	102	db_pubmed_info				101							-1		-1	PUBLI			C	D	P		S	100																-1	Push pubmed authors & institution to database
 SC	103	db_publi_ontology			101							-1		-1	PUBLI			C	D	P		S	/																-1	Push pubmed to database
 SC	104	db_publi_gene				101							-1		13	PUBLI			C	D	P		S	11|12|13|15|206														-1	Match genes to publications
 SC	105	db_publi_drug				101							-1		204	PUBLI			C	D	P		S	204|643																-1	Match drug to publications

--- a/BACKEND/SCRIPT/PUBLI/dl_pubmed.php
+++ b/BACKEND/SCRIPT/PUBLI/dl_pubmed.php
@@ -40,9 +40,9 @@ addLog("Create directory");
 addLog("Working directory:".$W_DIR);
 
 addLog("Get last refresh date");
-	/// Get the last refresh date from prd_pubmed job
+	/// Get the last refresh date from db_pubmed_info job
 	/// i.e. the last date the process was completely run
-	$PRD_PUBLI=$GLB_TREE[getJobIDByName('prd_pubmed')];
+	$PRD_PUBLI=$GLB_TREE[getJobIDByName('db_pubmed_info')];
 	$PUBLI_START_STATUS= ($PRD_PUBLI['TIME']['DEV_DIR']=='-1');
 	
 	$PREV_DIR=$R_DIR.'/'.$PRD_PUBLI['TIME']['DEV_DIR'];


### PR DESCRIPTION
- dl_pubmed was currently restarting from the prd_pubmed last successful date. However, in the initial run, this can lead to redownloading and reprocessing the whole pubmed IF it takes more than 3 days to process it initially. Therefore, we switch from prd_pubmed to db_pubmed_info last successful date to avoid that.
- A typo was introduced in CONFIG_JOB for db_pubmed_info for the conflict jobs.