### PR TITLE
Correct issue with isoform id shift

### DIFF
--- a/BACKEND/SCRIPT/CHEMBL/db_chembl_data.php
+++ b/BACKEND/SCRIPT/CHEMBL/db_chembl_data.php
@@ -2144,7 +2144,7 @@ $DEBUG=true;
 			$S_E=&$SEARCH_AC["'".$line['ac']."'"];
 			$isoform='';
 			$tab=explode("-",$line['iso_id']);
-			if (isset($tab[1]))$isoform=$tab[1]-1;
+			if (isset($tab[1]))$isoform=$tab[1];
 			$FOUND=false;
 			foreach ($S_E['POS'] as &$P)
 			{


### PR DESCRIPTION
- Patch: During the process of ChEMBL variant information, a shift in the isoform identifier was leading to missed mapping against uniprot protein isoforms. This patch correct the shift.